### PR TITLE
Fix eslint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "node": true
   },
   "parserOptions": {
+    "ecmaVersion": 2018,
     "sourceType": "module"
   },
   "rules": {


### PR DESCRIPTION
Issue Link: **NONE**

Fixed a small issue with ESLint throwing errors for ES2017 and ES2018 syntax.

### Testing Instructions

Make sure your editor is configured to display eslint errors inline, and you should no longer see an error for `async/await` or `...`

### Pre-Approval Checklist

These items must be completed before merging to master:

- [x] Documentation has been updated
- [x] Unit tests have been added/updated
- [x] All tests pass
